### PR TITLE
chore: harden monorepo bootstrap (compose + BOOTSTRAP.md + preflight)

### DIFF
--- a/BOOTSTRAP.md
+++ b/BOOTSTRAP.md
@@ -1,0 +1,231 @@
+# Bootstrap — Sangue Solidário em outra máquina
+
+> **Tempo estimado:** 20 min (15 min de build na primeira vez).
+> **Para quem:** dev novo na equipe, ou você mesmo num notebook que ainda não tem o sistema rodando (apresentação acadêmica, demo, deploy local de teste).
+
+Esse repo é o **backend principal** do PI e contém o `docker-compose.yml` que orquestra TODOS os 6 microsserviços + frontend + 4 bancos.
+
+---
+
+## Pré-requisitos
+
+- **Docker Desktop 24+** rodando (Windows: WSL2 backend)
+- **Git** e shell bash (Git Bash no Windows)
+- **8 GB RAM livre, 10 GB de disco**
+- **Portas livres no host:** `3000-3006`, `5432-5435`, `27017`
+
+Verifique com:
+
+```bash
+docker version
+docker info | grep "Server Version"
+```
+
+---
+
+## 1. Clonar todos os 7 repos como **siblings** (irmãos)
+
+⚠️ A estrutura de pastas é OBRIGATÓRIA — o `docker-compose.yml` referencia os outros repos com path relativo `../<repo>`.
+
+```bash
+mkdir -p sangue-solidario && cd sangue-solidario
+
+git clone https://github.com/c3ny/blood-stock-service
+git clone https://github.com/c3ny/sangue-solidario-nextjs
+git clone https://github.com/c3ny/users-service
+git clone https://github.com/c3ny/donation-service
+git clone https://github.com/c3ny/cdn-service-node
+git clone https://github.com/c3ny/campaign-service
+git clone https://github.com/c3ny/appointments-service-node
+```
+
+Estrutura final:
+
+```
+sangue-solidario/
+├── blood-stock-service/        ← compose mora aqui (este repo)
+├── sangue-solidario-nextjs/
+├── users-service/
+├── donation-service/
+├── cdn-service-node/
+├── campaign-service/
+└── appointments-service-node/
+```
+
+---
+
+## 2. Restaurar `.env` em cada repo
+
+O sistema precisa de **8 arquivos `.env`** (raiz + 7 subprojetos), que **NÃO ficam no git** porque contêm secrets reais (Cloudinary, Mapbox, Google OAuth, JWT, Cookie, Postgres password, etc).
+
+A pessoa responsável (owner) gera um pacote `env-pack.tar.gz` (~2 KB) na máquina principal e transfere por **canal seguro** (pen drive, e-mail privado, mensageria pessoal — **NUNCA cloud público sem expiração**).
+
+Receba o `env-pack.tar.gz`, coloque na raiz do `sangue-solidario/` e extraia:
+
+```bash
+# Estando na raiz sangue-solidario/
+tar xzf env-pack.tar.gz
+rm env-pack.tar.gz
+
+# Confirmar que os 8 .env foram criados
+ls .env */(.env) 2>/dev/null || true
+for f in .env */.env; do [ -f "$f" ] && echo "✓ $f ($(wc -l < $f) linhas)"; done
+```
+
+**Sem o env-pack:** copie os respectivos `.env.example` de cada repo para `.env` e preencha manualmente. Você vai precisar de credenciais Cloudinary, Mapbox token, Google OAuth Client ID, e gerar 3 secrets aleatórios (JWT, Cookie, Internal):
+
+```bash
+openssl rand -base64 48   # rode 3 vezes, um pra cada secret
+```
+
+---
+
+## 3. Pre-flight check
+
+```bash
+cd blood-stock-service
+./scripts/preflight.sh
+```
+
+Sai com **exit 0** se tudo OK. Se algo vermelho, siga as instruções no output (porta ocupada, `.env` faltando, repo sibling ausente, etc.) antes de continuar.
+
+---
+
+## 4. Subir tudo
+
+```bash
+docker compose up -d --build
+# ou: ./up.sh
+
+# Acompanhar progresso (Ctrl+C sai sem derrubar)
+docker compose logs -f
+```
+
+**1ª vez demora 10-15 min** — o Docker está buildando 7 imagens. As imagens ficam em cache; próximas subidas levam < 1 min.
+
+---
+
+## 5. Validar
+
+| URL | Esperado |
+|---|---|
+| <http://localhost:3000> | Home Sangue Solidário carrega (mapa + listas) |
+| <http://localhost:3002/api-docs> | Swagger users-service |
+| <http://localhost:3003/api-docs> | Swagger appointments-service |
+| <http://localhost:3004/docs> | Scalar blood-stock-service |
+| <http://localhost:3006/api/docs> | Swagger campaign-service |
+
+`docker compose ps` deve mostrar 11 containers `Up`.
+
+**Smoke test funcional rápido:**
+
+1. Cadastrar como DONOR → login → home mostra solicitações
+2. Cadastrar como COMPANY → painel `/hemocentros/painel` carrega
+3. Criar campanha (testa JWT do campaign-service)
+4. Agendar doação numa campanha (testa appointments-service)
+
+---
+
+## Troubleshooting
+
+### `https://localhost:3000` — `ERR_SSL_PROTOCOL_ERROR`
+
+HSTS cache do browser. Em Chrome/Edge:
+
+1. Abra `chrome://net-internals/#hsts`
+2. **Delete domain security policies** → digite `localhost` → Delete
+3. Feche TODAS as abas localhost e abra em aba anônima/incógnito
+
+Alternativa: use `http://127.0.0.1:3000` (HSTS é por host, IP escapa).
+
+### Mapbox: `An API access token is required`
+
+O token não foi embutido no build do nextjs. Confirme:
+
+```bash
+grep MAPBOX .env
+# Deve mostrar pk.eyJ... (não pk.xxx placeholder)
+```
+
+Se OK, force rebuild SÓ do nextjs:
+
+```bash
+docker compose build --no-cache nextjs-frontend
+docker compose up -d nextjs-frontend
+```
+
+### `database "campaigns_db" does not exist` (com S)
+
+`dist/` antigo no source ou imagem em cache:
+
+```bash
+cd ../campaign-service && rm -rf dist/
+cd ../blood-stock-service
+docker rmi -f $(docker images -q "*campaign-service*") 2>/dev/null
+docker builder prune -af
+docker compose build --no-cache campaign-service
+docker compose up -d --force-recreate campaign-service
+```
+
+### `connect ECONNREFUSED` no startup
+
+Race condition normal. O `depends_on` do compose só espera o container existir, não o Postgres aceitar conexão. NestJS retenta automaticamente até 9x. **Aguarde 30s** e veja se sobe.
+
+### Porta ocupada
+
+```bash
+# Linux/Mac/WSL/Git-Bash
+ss -tlnp | grep ":3000"
+# ou: lsof -i :3000
+```
+
+Mate o processo dono ou troque a porta no compose.
+
+### Container em loop de restart
+
+```bash
+docker compose logs --tail=50 <serviço>
+```
+
+Causas comuns:
+- `.env` mal-parseado (aspas extras, espaços ao redor de `=`)
+- Var crítica faltando
+- Postgres ainda inicializando (esperar mais 30s)
+
+### Reset completo (last resort — apaga TUDO)
+
+```bash
+docker compose down -v          # ⚠️ apaga volumes (banco zera)
+docker system prune -af --volumes  # ⚠️ apaga TODAS as imagens não-em-uso
+docker compose up -d --build
+```
+
+---
+
+## Modo standalone (rodar SÓ blood-stock para dev focado)
+
+Se quiser desenvolver apenas neste serviço sem subir todo o sistema:
+
+```bash
+docker compose -f docker-compose.standalone.yml up -d
+```
+
+Esse compose sobe apenas `bloodstock-service` + `postgres_bloodstock`, em uma rede isolada.
+
+---
+
+## Arquitetura de redes Docker
+
+O compose unificado cria 5 redes bridge isoladas. Containers só se enxergam dentro da mesma rede:
+
+| Rede | Containers |
+|---|---|
+| `blood-users-network` | users-service + bloodstock-service + 2 Postgres + **campaign-service** (validar JWT) |
+| `donation-network` | donation-service + Mongo |
+| `cdn-network` | cdn-service |
+| `campaign-network` | campaign-service + Postgres campaign |
+| `appointments-network` | appointments-service-node + Postgres appointments + campaign-service |
+
+O `nextjs-frontend` está em **todas** as redes (precisa falar com todos os backends).
+
+Dentro de cada rede, containers usam **nome do serviço** como hostname (ex: `http://bloodstock-service:3004`, `http://users-service:3002`).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -189,12 +189,21 @@ services:
       DB_USER: ${POSTGRES_USER}
       DB_PASS: ${POSTGRES_PASSWORD}
       DB_NAME: campaign_db
+      # main remota lê DB_DATABASE; branch local renomeou pra DB_NAME.
+      # Mantemos os dois pra compatibilidade até a branch nova ser merged.
+      DB_DATABASE: campaign_db
       JWT_SECRET: ${JWT_SECRET}
+      # Versão da main valida JWT chamando users-service via HTTP.
+      # Branch local valida com JWT_SECRET. Mantemos a URL pra compatibilidade.
+      USERS_SERVICE_URL: http://users-service:3002
       CORS_ORIGIN: http://localhost:3000
+      CORS_ORIGINS: http://localhost:3000
     depends_on:
       - postgres_campaign
     networks:
+      # blood-users-network adicionada pra que campaign-service alcance users-service.
       - campaign-network
+      - blood-users-network
 
   # ─── CDN SERVICE ───────────────────────────────────────────────
   cdn-service:

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Sangue Solidário — Pre-flight check
+# Roda diagnósticos antes de `docker compose up` pra detectar
+# problemas comuns que causaram dor em deploys anteriores.
+#
+# Uso: ./scripts/preflight.sh (a partir da pasta blood-stock-service/)
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+ok()   { echo -e "${GREEN}✓${NC} $1"; }
+warn() { echo -e "${YELLOW}⚠${NC} $1"; }
+fail() { echo -e "${RED}✗${NC} $1"; FAILED=1; }
+
+FAILED=0
+
+echo "=== Sangue Solidário — Pre-flight Check ==="
+echo ""
+
+# 1) Docker daemon
+echo "[1/6] Docker daemon"
+if docker info > /dev/null 2>&1; then
+  ok "Docker daemon está rodando"
+else
+  fail "Docker daemon NÃO está rodando — inicie o Docker Desktop e tente de novo"
+fi
+echo ""
+
+# 2) Portas livres
+echo "[2/6] Portas livres"
+PORTS_OK=1
+for port in 3000 3001 3002 3003 3004 3005 3006 5432 5433 5434 5435 27017; do
+  if (echo > /dev/tcp/localhost/$port) 2>/dev/null; then
+    fail "Porta $port OCUPADA"
+    PORTS_OK=0
+  fi
+done
+[ "$PORTS_OK" = "1" ] && ok "Todas as 12 portas livres (3000-3006, 5432-5435, 27017)"
+echo ""
+
+# 3) .env presente e populado
+echo "[3/6] Arquivo .env (compose lê variáveis daqui)"
+if [ -f .env ]; then
+  lines=$(wc -l < .env)
+  if [ "$lines" -lt 10 ]; then
+    fail ".env presente mas só tem $lines linhas (esperado ≥ 20 — provavelmente é o .env standalone, não o unificado)"
+  else
+    ok ".env presente com $lines linhas"
+  fi
+else
+  fail ".env NÃO encontrado — extraia o env-pack.tar.gz na pasta sangue-solidario/ primeiro"
+fi
+echo ""
+
+# 4) Sibling repos clonados
+echo "[4/6] Repos siblings (devem estar em ../)"
+SIBLINGS_OK=1
+for sibling in sangue-solidario-nextjs users-service donation-service cdn-service-node campaign-service appointments-service-node; do
+  if [ -f "../$sibling/Dockerfile" ]; then
+    ok "../$sibling/Dockerfile encontrado"
+  else
+    fail "../$sibling/Dockerfile AUSENTE — clone o repo como sibling de blood-stock-service"
+    SIBLINGS_OK=0
+  fi
+done
+echo ""
+
+# 5) Imagens problemáticas em cache (warning, não bloqueia)
+echo "[5/6] Imagens em cache que podem causar conflito"
+STALE_FOUND=0
+for stale in "campaign-service-app" "blood-stock-service_campaign-service" "campaign-service-campaign-service"; do
+  if docker images --format "{{.Repository}}" 2>/dev/null | grep -q "^${stale}$"; then
+    warn "Imagem antiga em cache: $stale"
+    warn "  Para apagar: docker rmi -f $stale"
+    STALE_FOUND=1
+  fi
+done
+[ "$STALE_FOUND" = "0" ] && ok "Nenhuma imagem antiga problemática em cache"
+echo ""
+
+# 6) Vars críticas no .env (apenas se .env existe)
+echo "[6/6] Variáveis críticas no .env"
+if [ -f .env ]; then
+  for var in JWT_SECRET COOKIE_SECRET POSTGRES_USER POSTGRES_PASSWORD CLOUDINARY_CLOUD_NAME NEXT_PUBLIC_MAPBOX_TOKEN; do
+    if grep -q "^$var=" .env 2>/dev/null; then
+      val=$(grep "^$var=" .env | cut -d= -f2- | tr -d '\r\n')
+      if [ -z "$val" ] || echo "$val" | grep -qE "^(change-me|pk\.xxx|placeholder|secret$|admin$)"; then
+        fail "$var presente no .env mas com placeholder/vazio: '$val'"
+      else
+        ok "$var configurada"
+      fi
+    else
+      fail "$var ausente no .env (necessária para compose ou build do frontend)"
+    fi
+  done
+else
+  warn "Pulando checagem de vars (.env não encontrado)"
+fi
+echo ""
+
+echo "==========================================="
+if [ "$FAILED" = "0" ]; then
+  echo -e "${GREEN}✓ Tudo verde. Pode rodar:${NC}"
+  echo "    docker compose up -d --build"
+  exit 0
+else
+  echo -e "${RED}✗ Falhas detectadas. Resolva acima e rode novamente.${NC}"
+  exit 1
+fi


### PR DESCRIPTION
- docker-compose.yml: paths ../X (was ./X), DB_DATABASE+DB_NAME compat, USERS_SERVICE_URL+CORS_ORIGINS for cross-version compat, connect campaign-service to blood-users-network for JWT auth lookup
- BOOTSTRAP.md: step-by-step para deploy em maquina nova com troubleshooting consolidado (HSTS cache, Mapbox token build-arg, dist/ velho, race condition)
- scripts/preflight.sh: valida Docker daemon, portas livres, .env, siblings, imagens em cache antes de subir o stack