### PR TITLE
ci: corrigir auto-tag detection e tratar tags orfas

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -68,10 +68,7 @@ jobs:
         id: version
         run: |
           git fetch --tags
-          LAST_TAG=$(git describe --tags `git rev-list --tags --max-count=1`)
-          if [ -z "$LAST_TAG" ]; then
-            LAST_TAG="v0.0.0"
-          fi
+          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
           echo "Versão Atual: $LAST_TAG"
 
           if [ "$LAST_TAG" = "v0.0.0" ]; then
@@ -87,15 +84,32 @@ jobs:
           MINOR=0
           PATCH=0
 
-          for COMMIT in "$COMMITS"; do
-            if [[ "$COMMIT" == *"BREAKING CHANGE"* ]]; then
+          # Regex em variaveis: bash 5 reclama de parens quando o regex e literal dentro de [[ ]]
+          re_breaking='^[a-z]+(\([^)]+\))?!:'
+          re_merge='^Merge[[:space:]]'
+          re_release='^chore\(release\):'
+          re_feat='^feat(\([^)]+\))?:'
+          re_patch='^(fix|perf|refactor|chore|docs|style|test|ci|build|revert)(\([^)]+\))?:'
+
+          # Itera linha a linha (heredoc <<< preserva newlines; for...in com aspas iterava 1 vez so)
+          while IFS= read -r COMMIT; do
+            # Ignora linhas vazias, merges e commits de release gerados pelo proprio CI
+            [ -z "$COMMIT" ] && continue
+            [[ "$COMMIT" =~ $re_merge ]] && continue
+            [[ "$COMMIT" =~ $re_release ]] && continue
+
+            # Conventional commits: detecta tipo no INICIO do subject
+            # - BREAKING CHANGE no body OU sufixo "!" (ex: feat!:, fix!:) -> MAJOR
+            # - feat: ou feat(scope): -> MINOR
+            # - fix|perf|refactor|chore|docs|style|test|ci|build|revert -> PATCH
+            if [[ "$COMMIT" == *"BREAKING CHANGE"* ]] || [[ "$COMMIT" =~ $re_breaking ]]; then
               MAJOR=1
-            elif [[ "$COMMIT" == *"feat"* ]]; then
-              MINOR=1
-            elif [[ "$COMMIT" == *"fix"* ]]; then
-              PATCH=1
+            elif [[ "$COMMIT" =~ $re_feat ]]; then
+              [ $MAJOR -eq 0 ] && MINOR=1
+            elif [[ "$COMMIT" =~ $re_patch ]]; then
+              [ $MAJOR -eq 0 ] && [ $MINOR -eq 0 ] && PATCH=1
             fi
-          done
+          done <<< "$COMMITS"
 
           CURRENT_VERSION=${LAST_TAG#v}
           NEW_VERSION=$CURRENT_VERSION
@@ -106,6 +120,14 @@ jobs:
           elif [[ $PATCH -eq 1 ]]; then
             NEW_VERSION=$(semver -i patch $CURRENT_VERSION)
           fi
+
+          # Tags orfas (commits squash-merged podem deixar tag em ref que nao e ancestral
+          # de origin/main; git describe ignora elas mas `git tag` sabe que existem).
+          # Se a versao calculada ja existe como tag, bumpa PATCH ate achar uma livre.
+          while git rev-parse "v$NEW_VERSION" >/dev/null 2>&1; do
+            echo "Tag v$NEW_VERSION ja existe (orfa ou nao-ancestral); incrementando PATCH"
+            NEW_VERSION=$(semver -i patch $NEW_VERSION)
+          done
 
           echo "Nova versão: $NEW_VERSION"
           echo "new_version=$NEW_VERSION" >> $GITHUB_ENV


### PR DESCRIPTION
- Loop iterava 1 vez so (for COMMIT in "$COMMITS" com aspas duplas trata $COMMITS como string unica). Trocado por while read linha-a-linha.
- Match de tipo agora usa regex em variavel (^feat:, ^fix:, ...) ao inves de substring solta — antes "Add feature toggle" disparava feat falso.
- Filtra Merge commits e chore(release) gerados pelo proprio CI.
- Estende PATCH bump para refactor/chore/perf/docs/style/test/ci/build/revert alem de fix — qualquer commit em main agora gera tag.
- Suporta sintaxe "!" para BREAKING (feat!:, fix!:, ...).
- Trata tags orfas: se v$NEW_VERSION ja existe (squash-merge pode deixar tag fora da ancestralidade), incrementa PATCH ate achar livre.
- Trocado git describe --tags `git rev-list --tags --max-count=1` por git describe --tags --abbrev=0 (mais robusto, ancora em HEAD).