### PR TITLE
ci: separar DOCKERHUB_NAMESPACE de DOCKERHUB_USERNAME

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -28,20 +28,22 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      # 🐳 Build e push (igual antes)
+      # 🐳 Build e push
+      # NAMESPACE = org Docker Hub (firec4io); USERNAME so para login (caiocesardevback).
+      # Separar permite usar conta de organizacao mesmo sem login direto pela org.
       - name: Build e push
         run: |
           docker build \
-            -t ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.HEROKU_APP_NAME }}:latest \
-            -t ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.HEROKU_APP_NAME }}:${{ env.VERSION }} .
+            -t ${{ secrets.DOCKERHUB_NAMESPACE }}/${{ secrets.HEROKU_APP_NAME }}:latest \
+            -t ${{ secrets.DOCKERHUB_NAMESPACE }}/${{ secrets.HEROKU_APP_NAME }}:${{ env.VERSION }} .
 
-          docker push ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.HEROKU_APP_NAME }}:latest
-          docker push ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.HEROKU_APP_NAME }}:${{ env.VERSION }}
+          docker push ${{ secrets.DOCKERHUB_NAMESPACE }}/${{ secrets.HEROKU_APP_NAME }}:latest
+          docker push ${{ secrets.DOCKERHUB_NAMESPACE }}/${{ secrets.HEROKU_APP_NAME }}:${{ env.VERSION }}
 
       # 🔽 PULL da imagem pronta (do Docker Hub)
       - name: Pull da imagem
         run: |
-          docker pull ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.HEROKU_APP_NAME }}:${{ env.VERSION }}
+          docker pull ${{ secrets.DOCKERHUB_NAMESPACE }}/${{ secrets.HEROKU_APP_NAME }}:${{ env.VERSION }}
 
       # 🔐 Login no Heroku Registry
       - name: Login Heroku Container Registry
@@ -54,7 +56,7 @@ jobs:
       - name: Tag imagem para Heroku
         run: |
           docker tag \
-            ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.HEROKU_APP_NAME }}:${{ env.VERSION }} \
+            ${{ secrets.DOCKERHUB_NAMESPACE }}/${{ secrets.HEROKU_APP_NAME }}:${{ env.VERSION }} \
             registry.heroku.com/${{ secrets.HEROKU_APP_NAME }}/web
 
       # 🚀 PUSH para Heroku


### PR DESCRIPTION
Conta corporativa (firec4io) e organization no Docker Hub: organizations nao fazem login, somente users. Antes USERNAME era usado para duas coisas (login e namespace da imagem) — ao usar credenciais de outro user para fazer login, o push ia pro namespace pessoal do user, nao da org.

Solucao: separar em dois secrets.
- DOCKERHUB_USERNAME: user que faz login (ex: caiocesardevback)
- DOCKERHUB_TOKEN:    PAT do user
- DOCKERHUB_NAMESPACE: org de destino (ex: firec4io)

Pre-requisitos no Docker Hub:
- Conta firec4io configurada como organization
- caiocesardevback adicionado como Owner ou em team com Repo Write
- Repo publico criado na org (auto-create pode falhar conforme permissoes)