### PR TITLE
ci: adicionar step de verificacao/criacao do repo no Docker Hub + atu…

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -28,6 +28,46 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      # 📂 Verifica se o repo existe no Docker Hub e cria se necessario
+      # (atende item Docker Hub #4 da Entrega 3 PI: "step para verificacao/criacao
+      #  do repositorio no Docker Hub").
+      - name: Verificar/criar repositorio no Docker Hub
+        env:
+          DH_USER: ${{ secrets.DOCKERHUB_USERNAME }}
+          DH_PASS: ${{ secrets.DOCKERHUB_TOKEN }}
+          DH_NAMESPACE: ${{ secrets.DOCKERHUB_NAMESPACE }}
+          DH_REPO: ${{ secrets.HEROKU_APP_NAME }}
+        run: |
+          # Login na API REST do Hub para obter JWT (registry login != API login)
+          HUB_TOKEN=$(curl -fsSL -H "Content-Type: application/json" \
+            -X POST -d "{\"username\":\"$DH_USER\",\"password\":\"$DH_PASS\"}" \
+            https://hub.docker.com/v2/users/login/ | jq -r .token)
+
+          if [ -z "$HUB_TOKEN" ] || [ "$HUB_TOKEN" = "null" ]; then
+            echo "❌ Falha no login da API Docker Hub"
+            exit 1
+          fi
+
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+            -H "Authorization: JWT $HUB_TOKEN" \
+            "https://hub.docker.com/v2/repositories/$DH_NAMESPACE/$DH_REPO/")
+
+          if [ "$STATUS" = "200" ]; then
+            echo "✓ Repositorio $DH_NAMESPACE/$DH_REPO ja existe"
+          elif [ "$STATUS" = "404" ]; then
+            echo "→ Criando repositorio publico $DH_NAMESPACE/$DH_REPO"
+            curl -fsSL -H "Authorization: JWT $HUB_TOKEN" \
+              -H "Content-Type: application/json" \
+              -X POST \
+              -d "{\"namespace\":\"$DH_NAMESPACE\",\"name\":\"$DH_REPO\",\"is_private\":false,\"description\":\"Sangue Solidario - $DH_REPO\"}" \
+              https://hub.docker.com/v2/repositories/
+            echo ""
+            echo "✓ Repositorio criado"
+          else
+            echo "❌ Status inesperado da API: HTTP $STATUS"
+            exit 1
+          fi
+
       # 🐳 Build e push
       # NAMESPACE = org Docker Hub (firec4io); USERNAME so para login (caiocesardevback).
       # Separar permite usar conta de organizacao mesmo sem login direto pela org.

--- a/README.md
+++ b/README.md
@@ -297,24 +297,33 @@ O frontend está em **todas** as redes (precisa falar com todos os backends). De
 
 ### Docker Hub (CI/CD)
 
+As imagens são publicadas em uma **organização** Docker Hub corporativa do PI (`firec4io`). O workflow usa **três secrets** distintos para isolar credencial de login do namespace de destino:
+
+| Secret | Valor | Uso |
+|---|---|---|
+| `DOCKERHUB_USERNAME` | `caiocesardevback` | User que faz login (organizations no Docker Hub não fazem login direto) |
+| `DOCKERHUB_TOKEN` | Personal Access Token | Senha do login |
+| `DOCKERHUB_NAMESPACE` | `firec4io` | Organização onde a imagem é publicada |
+
 A cada push na branch `main`, o workflow `.github/workflows/cd.yaml` automaticamente:
 
-1. Faz login no Docker Hub usando os secrets `DOCKERHUB_USERNAME` e `DOCKERHUB_TOKEN` (sem expor credenciais no workflow)
-2. Lê a TAG mais recente do versionamento Git (gerada pelo `ci.yaml` via semver)
-3. Faz `docker build` com **duas tags**:
-   - `:VERSION` — mesma tag do versionamento (ex: `v1.2.0`)
+1. Faz login no Docker Hub com `DOCKERHUB_USERNAME` + `DOCKERHUB_TOKEN` (credenciais nunca expostas no workflow — ficam em GitHub Secrets)
+2. **Verifica/cria o repositório público** `firec4io/blood-stock-service` na API Hub (idempotente — se já existe, segue)
+3. Lê a TAG mais recente do versionamento Git (gerada pelo `ci.yaml` via semver — `feat:` → MINOR, `fix:`/`chore:`/`refactor:` → PATCH, `BREAKING CHANGE` → MAJOR)
+4. Faz `docker build` com **duas tags**:
+   - `:VERSION` — mesma tag do versionamento (ex: `v0.7.1`)
    - `:latest` — sempre aponta para a última imagem publicada
-4. Faz `docker push` das duas tags para o repositório público
-5. Após publicar no Docker Hub, faz pull da imagem versionada e re-tagueia para `registry.heroku.com` (deploy contínuo)
+5. Faz `docker push` das duas tags para o repositório público da org
+6. Faz pull da imagem versionada, re-tagueia para `registry.heroku.com` e faz `heroku container:release` (deploy contínuo)
 
-**Repositório público:** `https://hub.docker.com/r/<DOCKERHUB_USERNAME>/<HEROKU_APP_NAME>`
+**Repositório público:** [`https://hub.docker.com/r/firec4io/blood-stock-service`](https://hub.docker.com/r/firec4io/blood-stock-service)
 
 ```bash
 # Pull da última versão
-docker pull <DOCKERHUB_USERNAME>/<HEROKU_APP_NAME>:latest
+docker pull firec4io/blood-stock-service:latest
 
 # Pull de uma versão específica
-docker pull <DOCKERHUB_USERNAME>/<HEROKU_APP_NAME>:v1.2.0
+docker pull firec4io/blood-stock-service:v0.7.1
 ```
 
 > O Docker Hub é **acumulativo** — todas as TAGs versionadas geradas pelo pipeline ficam disponíveis para rollback ou inspeção, espelhando as tags do GitHub.


### PR DESCRIPTION
…alizar README

- cd.yaml: novo step que faz login na API REST do Docker Hub (POST /v2/users/login/), verifica se firec4io/<repo> existe (GET /v2/repositories/<ns>/<repo>/) e cria publico se nao existir (POST /v2/repositories/). Idempotente; atende item Docker Hub #4 da Entrega 3 PI ("step para verificacao/criacao do repositorio").
- README.md: secao Docker Hub atualizada — explica os 3 secrets (USERNAME para login do user, NAMESPACE para org de destino, TOKEN como PAT), URL real do repo publico (firec4io/blood-stock-service), e novo step de criacao automatica.